### PR TITLE
Camlp5 8.00 alpha02 work

### DIFF
--- a/camlp5/Camlp5Helpers.ml
+++ b/camlp5/Camlp5Helpers.ml
@@ -102,7 +102,7 @@ module Pat = struct
       <:patt< $c$ $args$ >>
 
   let type_ ~loc lident =
-    PaTyp (loc, VaVal (Asttools.longident_lident_of_string_list loc (Longident.flatten lident)) )
+    <:patt< # $lilongid:Asttools.longident_lident_of_string_list loc (Longident.flatten lident)$ >>
 
   let record ~loc fs =
     <:patt< { $list:List.map (fun (l,r) -> (of_longident ~loc l, r) ) fs$ } >>
@@ -130,7 +130,7 @@ end
 
 let use_new_type ~loc name e =
   let p = <:patt< (type $lid:name$) >> in
-  <:expr< fun [ $list:[ (p,Ploc.VaVal None,e) ]$ ] >>
+  <:expr< fun [ $p$ -> $e$ ] >>
 
 module Exp = struct
   type t = MLast.expr
@@ -388,7 +388,7 @@ module Str = struct
             <:constructor< $uid:cd.pcd_name.txt$ of $list:args$ >>
           ) cds
         in
-        MLast.TySum (loc, Ploc.VaVal llslt)
+        <:ctyp< [ $list:llslt$ ] >>
       | _ -> assert false
 
     in
@@ -398,7 +398,7 @@ module Str = struct
     (* TODO *)
 
   let single_value ~loc pat body =
-    StVal (loc, Ploc.VaVal false, Ploc.VaVal [ pat,body, <:vala< [] >> ])
+    <:str_item< value $pat$ = $body$ >>
 
   let values ~loc ?(rec_flag=Ppxlib.Recursive) vbs =
     let vbs = List.map (fun (p,e) -> (p,e,<:vala< [] >>)) vbs in
@@ -442,7 +442,6 @@ module Str = struct
     let ltt = [] in
     let t =
       let llslt = List.map (fun (name,typ) ->
-          (* TODO: error about gadts may be here *)
           <:constructor< $uid:name$ : $typ$ >>
         ) ts in
       <:ctyp< [ $list:llslt$ ] >>
@@ -533,7 +532,7 @@ module Sig = struct
             <:constructor< $uid:cd.pcd_name.txt$ of $list:args$ >>
           ) cds
         in
-        MLast.TySum (loc, Ploc.VaVal llslt)
+        <:ctyp< [ $list:llslt$ ] >>
       | Ptype_abstract -> begin
           match td.ptype_manifest with
           | None -> assert false
@@ -576,7 +575,7 @@ module Sig = struct
       let cs =
         List.map (fun (name,t) -> <:constructor< $uid:name$ : $t$ >> )
           constructors in
-      (TySum (loc, VaVal cs))
+      <:ctyp< [ $list:cs$ ] >>
     in
     let tdPrm = List.init params_count (fun n ->
             (VaVal (Some (Printf.sprintf "dummy%d" n)), None)) in
@@ -596,6 +595,7 @@ module Sig = struct
   let module_ ~loc (_,name,mtyp) =
     <:sig_item< module $uid:name$ : $mtyp:mtyp$ >>
 
+  (* TODO: Kakadu, what is this?  I don't recognize this.  It doesn't seem to exist in Ocaml, and the construct appears to be something leftover in camlp5. *)
   let modtype ~loc (_loc,s,mt_opt) =
     let mt =
       match mt_opt with

--- a/camlp5/Camlp5Helpers.ml
+++ b/camlp5/Camlp5Helpers.ml
@@ -385,22 +385,14 @@ module Str = struct
               | Pcstr_record _ -> assert false
               | Pcstr_tuple ts ->  List.map Typ.from_caml ts
             in
-            (loc, VaVal cd.pcd_name.txt, VaVal args, None, <:vala< [] >>)
+            <:constructor< $uid:cd.pcd_name.txt$ of $list:args$ >>
           ) cds
         in
         MLast.TySum (loc, Ploc.VaVal llslt)
       | _ -> assert false
 
     in
-    let t =
-      { tdNam = VaVal (loc, VaVal td.ptype_name.txt);
-        tdPrm = VaVal tdPrm;
-        tdPrv = VaVal false;
-        tdDef;
-        tdCon = VaVal [] ;
-        tdIsDecl = true ;
-        tdAttributes = <:vala< [] >>
-      }
+    let t = <:type_decl< $tp:(loc, VaVal td.ptype_name.txt)$ $list:tdPrm$ = $tdDef$ >>
     in
     <:str_item< type $list:[t]$ >>
     (* TODO *)
@@ -427,14 +419,8 @@ module Str = struct
     <:str_item< class $list:[c]$ >>
 
   let tdecl ~loc ~name ~params rhs =
-    let t = { tdNam = VaVal (loc, VaVal name)
-            ; tdPrm = VaVal (List.map (fun s -> (VaVal (Some s),None)) params)
-            ; tdPrv = VaVal false
-            ; tdDef = rhs
-            ; tdCon = VaVal []
-            ; tdIsDecl = true
-            ; tdAttributes = <:vala< [] >>
-            }
+    let tdPrm = List.map (fun s -> (VaVal (Some s),None)) params in
+    let t = <:type_decl< $tp:(loc, VaVal name)$ $list:tdPrm$ = $rhs$ >>
     in
     <:str_item< type $list:[t]$ >>
 
@@ -457,7 +443,7 @@ module Str = struct
     let t =
       let llslt = List.map (fun (name,typ) ->
           (* TODO: error about gadts may be here *)
-          (loc,VaVal name, VaVal [], Some typ, <:vala< [] >>)
+          <:constructor< $uid:name$ : $typ$ >>
         ) ts in
       <:ctyp< [ $list:llslt$ ] >>
     in
@@ -544,7 +530,7 @@ module Sig = struct
               | Pcstr_record _ -> assert false
               | Pcstr_tuple ts -> List.map Typ.from_caml ts
             in
-            (loc, VaVal cd.pcd_name.txt, VaVal args, None, <:vala< [] >>)
+            <:constructor< $uid:cd.pcd_name.txt$ of $list:args$ >>
           ) cds
         in
         MLast.TySum (loc, Ploc.VaVal llslt)
@@ -556,15 +542,7 @@ module Sig = struct
       | _ -> assert false
 
     in
-    let t =
-      { tdNam = VaVal (loc, VaVal td.ptype_name.txt);
-        tdPrm = VaVal tdPrm;
-        tdPrv = VaVal false;
-        tdDef;
-        tdCon = VaVal [] ;
-        tdIsDecl = true ;
-        tdAttributes = <:vala< [] >>
-      }
+    let t = <:type_decl< $tp:(loc, VaVal td.ptype_name.txt)$ $list:tdPrm$ = $tdDef$ >>
     in
     <:sig_item< type $list:[t]$ >>
 
@@ -596,20 +574,13 @@ module Sig = struct
     let tdDef =
       (* TODO: error about gadts may be here *)
       let cs =
-        List.map (fun (name,t) -> (loc, VaVal name, VaVal [], Some t, <:vala< [] >>) )
+        List.map (fun (name,t) -> <:constructor< $uid:name$ : $t$ >> )
           constructors in
       (TySum (loc, VaVal cs))
     in
-    let td =
-      { tdNam = VaVal (loc, VaVal name);
-        tdPrm = VaVal (List.init params_count (fun n ->
-            (VaVal (Some (Printf.sprintf "dummy%d" n)), None)) );
-        tdPrv = VaVal false;
-        tdDef;
-        tdCon = VaVal [] ;
-        tdIsDecl = true ;
-        tdAttributes = <:vala< [] >>
-      }
+    let tdPrm = List.init params_count (fun n ->
+            (VaVal (Some (Printf.sprintf "dummy%d" n)), None)) in
+    let td = <:type_decl< $tp:(loc, VaVal name)$ $list:tdPrm$ = $tdDef$ >>
     in
     <:sig_item< type $list:[td]$ >>
 
@@ -617,15 +588,8 @@ module Sig = struct
 
   let tdecl_abstr: loc:loc -> string -> string option list -> t = fun ~loc name params ->
 
-    let td =
-      { tdNam = VaVal (loc, VaVal name);
-        tdPrm = VaVal (List.map (fun s -> (VaVal s,None)) params);
-        tdPrv = VaVal false;
-        tdDef = <:ctyp< 'abstract >>;
-        tdCon = VaVal [] ;
-        tdIsDecl = true ;
-        tdAttributes = <:vala< [] >>
-      }
+    let tdPrm = List.map (fun s -> (VaVal s,None)) params in
+    let td = <:type_decl< $tp:(loc, VaVal name)$ $list:tdPrm$ = 'abstract >>
     in
     <:sig_item< type $list:[td]$ >>
 


### PR DESCRIPTION
Kakadu, here are some changes to get GT working with the latest (NOT YET RELEASED) camlp5 8.00~alpha02.  As you will see, mostly it's switching to using more quotations (which should be more-immune to changes in the AST, since concrete syntax changes less-frequently).  The *particular* problem you had, was .... a BUG.  My bad, man.  My bad.  That function hadn't been updated.  It's fixed now, and I've put an MLI file in place so it'll stay fixed.  Sigh.

Please hold off on merging this until I release alpha02 -- that will make it most-effortless to deal with building, yes?